### PR TITLE
Fix compilation error on Ubuntu.

### DIFF
--- a/lib/Target/M6502/M6502TargetMachine.cpp
+++ b/lib/Target/M6502/M6502TargetMachine.cpp
@@ -28,7 +28,7 @@ M6502TargetMachine::M6502TargetMachine(const Target &T, const Triple &TT,
     : LLVMTargetMachine(T, "e-p:16:8-n8", TT, CPU, FS, Options,
                         RM.getValueOr(Reloc::Static),
                         CM.getValueOr(CodeModel::Small), OL),
-      TLOF(std::make_unique<M6502TargetObjectFile>()),
+      TLOF(llvm::make_unique<M6502TargetObjectFile>()),
       Subtarget(TT, CPU, FS, *this) {
 
   initAsmInfo();


### PR DESCRIPTION
LLVM itself does not refer to std::make_unique() as your code does.  Instead, it refers to llvm::make_unique(), which does the same thing.  This can be confirmed by grepping the rest of LLVM.

This change makes your codebase compile on Ubuntu 16.04 and probably other platforms as well.